### PR TITLE
Add grunt/gulp smoke tests

### DIFF
--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -2,15 +2,16 @@
 'use strict';
 var path = require('path');
 var helpers = require('yeoman-generator').test;
+var rimraf = require('rimraf');
 
 describe('cf generator', function () {
   this.timeout(10000);
+
   beforeEach(function (done) {
     helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
       if (err) {
         return done(err);
       }
-
       this.app = helpers.createGenerator('cf:app', [
         '../../app'
       ]);
@@ -18,18 +19,21 @@ describe('cf generator', function () {
     }.bind(this));
   });
 
-  it('creates expected files', function (done) {
+  afterEach(function (done) {
+    rimraf(path.join(__dirname, 'temp'), done);
+  });
+
+  it('creates expected files when run', function (done) {
     var expected = [
       // add files you expect to exist here.
       '.bowerrc',
       '.eslintrc',
       '.gitignore',
       'bower.json',
-      'package.json',
-      'Gruntfile.js'
+      'package.json'
     ];
     helpers.mockPrompt(this.app, {
-      'someOption': true
+      'buildToolChoice': 'grunt'
     });
     this.app.options['skip-install'] = true;
     this.app.run({}, function () {
@@ -37,4 +41,33 @@ describe('cf generator', function () {
       done();
     });
   });
+
+  it('creates a gruntfile when Grunt is selected', function (done) {
+    var expected = [
+      'Gruntfile.js'
+    ];
+    helpers.mockPrompt(this.app, {
+      'buildToolChoice': 'grunt'
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+
+  it('creates a gulpfile when Gulp is selected', function (done) {
+    var expected = [
+      'gulpfile.js'
+    ];
+    helpers.mockPrompt(this.app, {
+      'buildToolChoice': 'gulp'
+    });
+    this.app.options['skip-install'] = true;
+    this.app.run({}, function () {
+      helpers.assertFile(expected);
+      done();
+    });
+  });
+
 });


### PR DESCRIPTION
Adds smoke tests to verify https://github.com/cfpb/generator-cf/pull/103 works as expected.

## Additions

- Tests to verify gruntfile/gulpfile is being created.

## Testing

- `npm test`

## Review

- @jimmynotjim 

## Notes

- Code coverage still blows but now it's slightly better.